### PR TITLE
removed resolve-url-loader after postcss-loader

### DIFF
--- a/template/config/style-loaders.js
+++ b/template/config/style-loaders.js
@@ -13,18 +13,17 @@ const loaders = [
             localIdentName: '[name]__[local]---[hash:base64:5]'
         }
     },
-    { loader: 'resolve-url-loader', options: { sourceMap: true } },
-    { loader: 'postcss-loader', options: { sourceMap: true } },
     'resolve-url-loader',
+    'postcss-loader',
     { loader: 'sass-loader',
-        options: {
-            sourceMap: true,
-            precision: 10,
+        query: {
             includePaths: [
                 paths.toAbsPath('src.assets/styles'),
                 'node_modules'
             ],
-            outputStyle: 'expanded'
+            outputStyle: 'expanded',
+            sourceMap: true,
+            precision: 10
         }
     }
 ];


### PR DESCRIPTION
After few tests it turned out that using `resolve-url-loader` either after `css-loader` and `postcss-loader` messes up something. There are a lot of issues concerning `resolve-url-loader` and how it works with source-maps.
I believe that using `resolve-url-loader` between `postcss-loader` and `scss-loader` prevent `scss-loader` to find import paths.

This PR fixes all the console warning on Windows (issue #4 ), preserving the functionalities.